### PR TITLE
レイアウト調整

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,12 +15,3 @@
  *= require jquery-ui
  *= require jquery.tagsinput.min
  */
-
-*{
-  font-family:'Chalkboard SE','PT Mono','Courier','Verdana','Hannotate TC','ヒラギノ角ゴシック','Hiragino Sans','ＭＳ Ｐゴシック','MS PGothic',sans-serif;
-  
-}
-
- body{
-   background-color:#6ef3d6;
- }

--- a/app/assets/stylesheets/nutrients.scss
+++ b/app/assets/stylesheets/nutrients.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the nutrients controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/nutrients/new.scss
+++ b/app/assets/stylesheets/nutrients/new.scss
@@ -2,8 +2,7 @@
   .center-content{
     .nutrient-post-form{
       display: flex;
-      flex-flow: column;
-
+      flex-direction: column;
     }
   }
 }

--- a/app/assets/stylesheets/recipes/index.scss
+++ b/app/assets/stylesheets/recipes/index.scss
@@ -22,7 +22,6 @@
         margin: 1rem;
         border-radius: 1rem;
         background-color: white;
-        list-style: none;
       }
     }
   }

--- a/app/assets/stylesheets/recipes/index.scss
+++ b/app/assets/stylesheets/recipes/index.scss
@@ -7,13 +7,6 @@ li{
 }
 
 .main-contents{
-  position: relative;
-  top: 8vh;
-  min-height: 92vh;
-  box-sizing: border-box;
-  display: flex;
-  padding-bottom: 10vh;
-  
   p{
     margin-bottom: 5vh;
     text-align: center;
@@ -41,12 +34,6 @@ li{
   width: 32vw;
   
   border-radius: 1rem;
-}
-
-.center-content {
-  height: 100%;
-  background-color: #ace7ef;
-  padding: 1rem;
 }
 
 .jscroll-inner{

--- a/app/assets/stylesheets/recipes/index.scss
+++ b/app/assets/stylesheets/recipes/index.scss
@@ -1,53 +1,34 @@
-// 〜〜〜〜ページ全体〜〜〜〜
-
-$font_pop:'Chalkboard SE','PT Mono','Courier','Verdana','Hannotate TC','ヒラギノ角ゴシック','Hiragino Sans','ＭＳ Ｐゴシック','MS PGothic',sans-serif;
-
-li{
-  list-style: none;
-}
-
-.main-contents{
-  p{
-    margin-bottom: 5vh;
-    text-align: center;
+.posted-recipes-contents{
+  .recipe-lists{
+    text-decoration: none;
+    .recipe-list{
+      .recipe-list-contents{
+        display: flex;
+        .recipe-text-contents{
+          box-sizing: border-box;
+          width: 30vw;
+        }
+        .recipe-image-content{
+          box-sizing: border-box;
+          width: 32vw;
+          border-radius: 1rem;
+        }
+      }
+    }
+    .jscroll-inner{
+      li{
+        box-sizing: border-box;
+        padding: 1rem;
+        margin: 1rem;
+        border-radius: 1rem;
+        background-color: white;
+        list-style: none;
+      }
+    }
   }
 }
 
-// 〜〜〜〜ページ全体〜〜〜〜
-
-// 〜〜〜〜中央のコンテンツ〜〜〜〜
-.recipe-list{
-  text-decoration: none;
-}
-
-.recipe-list-contents{
-  display: flex;
-}
-
-.recipe-text-contents{
-  box-sizing: border-box;
-  width: 30vw;
-}
-
-.recipe-image-content{
-  box-sizing: border-box;
-  width: 32vw;
-  
-  border-radius: 1rem;
-}
-
-.jscroll-inner{
-  li{
-    box-sizing: border-box;
-    padding: 1rem;
-    margin: 1rem;
-
-    background-color: white;
-  }
-}
-
-nav.pagination {
+// ペーネーションの「次・前」ボタン非表示
+nav.pagination{
   display: none;
 }
-
-// 〜〜〜〜中央のコンテンツ〜〜〜〜

--- a/app/assets/stylesheets/recipes/index.scss
+++ b/app/assets/stylesheets/recipes/index.scss
@@ -6,7 +6,7 @@ li{
   list-style: none;
 }
 
-.main-content{
+.main-contents{
   position: relative;
   top: 8vh;
   min-height: 92vh;

--- a/app/assets/stylesheets/recipes/new.scss
+++ b/app/assets/stylesheets/recipes/new.scss
@@ -4,7 +4,6 @@
   min-height: 92vh;
   box-sizing: border-box;
   padding: 2rem 2rem 10vh 15rem;
-  
   .recipe-post-text{
     text-align: center;
   }
@@ -12,7 +11,6 @@
     display: flex;
     flex-flow: column;
     width: 50vw;
-
     #image-preview{
       display: flex;
       div{
@@ -22,9 +20,7 @@
         }
       }
     }
-
     input[name="commit"]{
-      
       width: 5rem;
     }
   }

--- a/app/assets/stylesheets/recipes/new.scss
+++ b/app/assets/stylesheets/recipes/new.scss
@@ -9,7 +9,7 @@
   }
   form{
     display: flex;
-    flex-flow: column;
+    flex-direction: column;
     width: 50vw;
     #image-preview{
       display: flex;

--- a/app/assets/stylesheets/recipes/show.scss
+++ b/app/assets/stylesheets/recipes/show.scss
@@ -1,10 +1,10 @@
 .recipe-show-contents{
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
   padding-left: 5rem;
   .recipe-show-items{
     display: flex;
-    flex-flow: column;
+    flex-direction: column;
 
     .recipe-title-contents{
       display: flex;
@@ -24,14 +24,19 @@
     }
     .recipe-text-contents{
       display: flex;
-      flex-flow: column;
+      flex-direction: column;
   }
   .recipe-show-items{
 
     }
   }
   .posted-comment{
-
+    display: flex;
+    flex-direction: column;
+    p{
+      align-items: center;
+      justify-content: center;
+    }
   }
   .comment-contents{
 

--- a/app/assets/stylesheets/recipes/show.scss
+++ b/app/assets/stylesheets/recipes/show.scss
@@ -34,8 +34,6 @@
     display: flex;
     flex-direction: column;
     p{
-      align-items: center;
-      justify-content: center;
     }
   }
   .comment-contents{

--- a/app/assets/stylesheets/recipes/show.scss
+++ b/app/assets/stylesheets/recipes/show.scss
@@ -1,18 +1,39 @@
-.recipe-show{
-  position: relative;
-  top: 8vh;
-  box-sizing: border-box;
-  padding-bottom: 5vh;
-  padding: 2rem 2rem 5vh 2rem;
-  min-height: 100vh;
+.recipe-show-contents{
   display: flex;
-  .recipe-show-contents{
-    min-height: 100vh;
+  flex-flow: column;
+  padding-left: 5rem;
+  .recipe-show-items{
     display: flex;
     flex-flow: column;
-     padding-left: 5rem;
-    .recipe-text-contents{
-      
+
+    .recipe-title-contents{
+      display: flex;
+      .recipe-title{
+  
+      }
+      .star-btn{
+  
+      }
+      .recipe-user{
+  
+      }
     }
+    .recipe-image-content{
+      width: 45vw;
+      height: 50vh;
+    }
+    .recipe-text-contents{
+      display: flex;
+      flex-flow: column;
+  }
+  .recipe-show-items{
+
+    }
+  }
+  .posted-comment{
+
+  }
+  .comment-contents{
+
   }
 }

--- a/app/assets/stylesheets/shared/center.scss
+++ b/app/assets/stylesheets/shared/center.scss
@@ -1,0 +1,7 @@
+.center-contents {
+  height-min: 87hv;
+  background-color: #ace7ef;
+  padding: 1rem;
+  box-sizing: border-box;
+  width: 75vw;
+}

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -4,6 +4,7 @@
   height: 5vh;
   width: 100vw;
   display: flex;
+  box-sizing: border-box;
   background-color: #6ef3d6;
 }
 

--- a/app/assets/stylesheets/shared/footer.scss
+++ b/app/assets/stylesheets/shared/footer.scss
@@ -1,4 +1,4 @@
-.footer-content{
+.footer-contents{
   position: relative;
   bottom: 0;
   height: 5vh;

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -7,6 +7,7 @@ a{
 .header-contents{
   z-index: 2;
   position: fixed;
+  box-sizing: border-box;
   height: 8vh;
   width: 100vw;
   background-color:#6ef3d6;

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -4,7 +4,7 @@ a{
   text-decoration: none;
 }
 
-.header-all{
+.header-contents{
   z-index: 2;
   position: fixed;
   height: 8vh;
@@ -13,7 +13,7 @@ a{
   display: flex;
 }
 
-.header-content{
+.header-items{
   display: flex;
   align-items: center;
   height: 100%;

--- a/app/assets/stylesheets/shared/left.scss
+++ b/app/assets/stylesheets/shared/left.scss
@@ -6,9 +6,10 @@
 
 // 〜〜〜〜左側のコンテンツ〜〜〜〜
 
-.left-content {
+.left-contents {
   box-sizing: border-box;
-  min-height: 92vh;
+  min-height: 87vh;
+  box-sizing: border-box;
   width: 25vw;
   padding: 3vh 3vh 0 3vh;
   background-color: #cefff1;

--- a/app/assets/stylesheets/shared/main.scss
+++ b/app/assets/stylesheets/shared/main.scss
@@ -1,0 +1,8 @@
+.main-contents{
+  position: relative;
+  top: 8vh;
+  min-height: 92vh;
+  box-sizing: border-box;
+  display: flex;
+  padding-bottom: 10vh;
+}

--- a/app/assets/stylesheets/shared/main.scss
+++ b/app/assets/stylesheets/shared/main.scss
@@ -1,7 +1,7 @@
 .main-contents{
   position: relative;
   top: 8vh;
-  min-height: 92vh;
+  min-height: 87vh;
   box-sizing: border-box;
   display: flex;
   padding-bottom: 10vh;

--- a/app/assets/stylesheets/shared/orverall.scss
+++ b/app/assets/stylesheets/shared/orverall.scss
@@ -9,3 +9,7 @@ $font_pop:'Chalkboard SE','PT Mono','Courier','Verdana','Hannotate TC','ヒラ�
 body{
   background-color:#6ef3d6;
 }
+
+li{
+  list-style: none;
+}

--- a/app/assets/stylesheets/shared/orverall.scss
+++ b/app/assets/stylesheets/shared/orverall.scss
@@ -1,0 +1,11 @@
+$font_pop:'Chalkboard SE','PT Mono','Courier','Verdana','Hannotate TC','ヒラギノ角ゴシック','Hiragino Sans','ＭＳ Ｐゴシック','MS PGothic',sans-serif;
+
+// 全体のフォントを指定
+*{
+  font-family: $font_pop;
+}
+
+// ページ全体の背景色を指定
+body{
+  background-color:#6ef3d6;
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,28 @@
-<h2>ログイン</h2>
+<div class="devise-contents">
+  <h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email, "登録メールアドレス" %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password, "パスワード" %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <%= f.label :email, "登録メールアドレス" %><br />
+      <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    </div>
+
+    <div class="field">
+      <%= f.label :password, "パスワード" %><br />
+      <%= f.password_field :password, autocomplete: "current-password" %>
+    </div>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="field">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </div>
+    <% end %>
+
+    <div class="actions">
+      <%= f.submit "ログイン" %>
     </div>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "ログイン" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,4 +1,5 @@
 <% if user_signed_in? %>
+  <%# recipe.idの変数recipeは、renderされた時に渡された@recipe %>
   <% if !Favorite.exists?(user_id: current_user.id, recipe_id: recipe.id) %>
     <span class="star-icon1">☆<%= recipe.favorites.count %></span>
     <%= link_to recipe_favorites_path(recipe.id), method: :post, remote: true, class: "favorite-btn" do %>
@@ -10,4 +11,7 @@
     <% end %>
     <span class="star-count2"><%= recipe.favorites.count %></span>
   <% end %> 
+<% else %>
+  <i class="fas fa-star star-icon2">☆</i>
+  <span class="star-count2"><%= recipe.favorites.count %></span>
 <% end %>

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -1,5 +1,5 @@
 <% if user_signed_in? %>
-  <%# recipe.idの変数recipeは、renderされた時に渡された@recipe %>
+  <%# 変数recipeは、renderされた時に渡された@recipeが格納されている %>
   <% if !Favorite.exists?(user_id: current_user.id, recipe_id: recipe.id) %>
     <span class="star-icon1">☆<%= recipe.favorites.count %></span>
     <%= link_to recipe_favorites_path(recipe.id), method: :post, remote: true, class: "favorite-btn" do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,9 @@
 
   <body>
     <%= render "shared/header" %>
-    <%= yield %>
+     <div class="main-content">
+        <%= yield %>
+      </div>
     <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,12 @@
   <body>
     <%= render "shared/header" %>
      <div class="main-content">
-        <%= yield %>
+        <div class="left-contents">
+          <%= render "shared/complex_search" %>
+        </div>
+        <div class="center-contents">
+          <%= yield %>
+        </div>
       </div>
     <%= render "shared/footer" %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,14 +14,9 @@
 
   <body>
     <%= render "shared/header" %>
-     <div class="main-content">
-        <div class="left-contents">
-          <%= render "shared/complex_search" %>
-        </div>
-        <div class="center-contents">
-          <%= yield %>
-        </div>
-      </div>
+     <div class="main-contents">
+       <%= yield %>
+     </div>
     <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/nutrients/new.html.erb
+++ b/app/views/nutrients/new.html.erb
@@ -1,18 +1,16 @@
-<div class ="main-content">
-  <div class="left-content">
-  <%= render "shared/complex_search" %>
-  </div>
-  <div class="center-content">
-    <%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
-      <%= n.label "栄養の名前" %>
-      <%= n.text_field :nutrient_name %>
-      <%= n.label "一言コメント" %>
-      <%= n.text_field :nutrient_comment %>
-      <%= n.label "説明" %>
-      <%= n.text_area :nutrient_content %>
-      <%= n.label "イメージ画像" %>
-      <%= n.file_field :image %>
-      <%= n.submit %>
-    <% end %>
-  </div>
+<div class="left-content">
+<%= render "shared/complex_search" %>
+</div>
+<div class="center-content">
+  <%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
+    <%= n.label "栄養の名前" %>
+    <%= n.text_field :nutrient_name %>
+    <%= n.label "一言コメント" %>
+    <%= n.text_field :nutrient_comment %>
+    <%= n.label "説明" %>
+    <%= n.text_area :nutrient_content %>
+    <%= n.label "イメージ画像" %>
+    <%= n.file_field :image %>
+    <%= n.submit %>
+  <% end %>
 </div>

--- a/app/views/nutrients/new.html.erb
+++ b/app/views/nutrients/new.html.erb
@@ -1,16 +1,11 @@
-<div class="left-content">
-<%= render "shared/complex_search" %>
-</div>
-<div class="center-content">
-  <%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
-    <%= n.label "栄養の名前" %>
-    <%= n.text_field :nutrient_name %>
-    <%= n.label "一言コメント" %>
-    <%= n.text_field :nutrient_comment %>
-    <%= n.label "説明" %>
-    <%= n.text_area :nutrient_content %>
-    <%= n.label "イメージ画像" %>
-    <%= n.file_field :image %>
-    <%= n.submit %>
-  <% end %>
-</div>
+<%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
+  <%= n.label "栄養の名前" %>
+  <%= n.text_field :nutrient_name %>
+  <%= n.label "一言コメント" %>
+  <%= n.text_field :nutrient_comment %>
+  <%= n.label "説明" %>
+  <%= n.text_area :nutrient_content %>
+  <%= n.label "イメージ画像" %>
+  <%= n.file_field :image %>
+  <%= n.submit %>
+<% end %>

--- a/app/views/nutrients/new.html.erb
+++ b/app/views/nutrients/new.html.erb
@@ -1,11 +1,14 @@
-<%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
-  <%= n.label "栄養の名前" %>
-  <%= n.text_field :nutrient_name %>
-  <%= n.label "一言コメント" %>
-  <%= n.text_field :nutrient_comment %>
-  <%= n.label "説明" %>
-  <%= n.text_area :nutrient_content %>
-  <%= n.label "イメージ画像" %>
-  <%= n.file_field :image %>
-  <%= n.submit %>
-<% end %>
+<%= render "shared/complex_search" %>
+<div class="center-contents">
+  <%= form_with model:@nutrient, url: nutrients_path, class: "nutrient-post-form" do |n| %>
+    <%= n.label "栄養の名前" %>
+    <%= n.text_field :nutrient_name %>
+    <%= n.label "一言コメント" %>
+    <%= n.text_field :nutrient_comment %>
+    <%= n.label "説明" %>
+    <%= n.text_area :nutrient_content %>
+    <%= n.label "イメージ画像" %>
+    <%= n.file_field :image %>
+    <%= n.submit %>
+  <% end %>
+</div>

--- a/app/views/nutrients/show.html.erb
+++ b/app/views/nutrients/show.html.erb
@@ -1,9 +1,12 @@
-<div class="nutrient-name">
-  <%= @nutrient.nutrient_name %>
-</div>
-<div class="nutrient-image">
-  <%= image_tag @nutrient.image %>
-</div>
-<div classs="nitrient-content">
-  <%= @nutrient.nutrient_content %>
+<%= render "shared/complex_search" %>
+<div class="center-contents">
+  <div class="nutrient-name">
+    <%= @nutrient.nutrient_name %>
+  </div>
+  <div class="nutrient-image">
+    <%= image_tag @nutrient.image %>
+  </div>
+  <div classs="nitrient-content">
+    <%= @nutrient.nutrient_content %>
+  </div>
 </div>

--- a/app/views/nutrients/show.html.erb
+++ b/app/views/nutrients/show.html.erb
@@ -1,16 +1,9 @@
-<div class ="main-content">
-  <div class="left-content">
-  <%= render "shared/complex_search" %>
-  </div>
-  <div class="center-content">
-    <div class="nutrient-name">
-      <%= @nutrient.nutrient_name %>
-    </div>
-    <div class="nutrient-image">
-      <%= image_tag @nutrient.image %>
-    </div>
-    <div classs="nitrient-content">
-      <%= @nutrient.nutrient_content %>
-    </div>
-  </div>
+<div class="nutrient-name">
+  <%= @nutrient.nutrient_name %>
+</div>
+<div class="nutrient-image">
+  <%= image_tag @nutrient.image %>
+</div>
+<div classs="nitrient-content">
+  <%= @nutrient.nutrient_content %>
 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,48 +1,42 @@
-<div class="left-content">
-<%= render "shared/complex_search" %>
+<div class="highright-recipes-title">
+  人気レシピ一覧
 </div>
-<div class="center-content">
-  <div class="highright-recipes-title">
-    人気レシピ一覧
-  </div>
-  <div class="highlight-recipes-content">
-    <ul class="recipe-lists jscroll">
-      <% @search_recipes.each do |r| %>
-        <li>
-          <div class="lists">
-            <%# list要素をリンク化%>
-            <%= link_to recipe_path(r.id),class: "recipe-list" do %>
-              <div class="recipe-list-contents">
-                <div class="recipe-text-contents">
-                  <h3 class="recipe-title">
-                    <%= r.title %>
-                  </h3>
-                  <br>
-                  登録タグ
-                  <br>
-                  <% r.tags.each do |t| %>
-                    <%= t.tag_name %>
-                  <% end %>
-                  <br>
-                  <br>
-                  栄養素
-                  <br>
-                  <% r.nutrients.each do |n| %>
-                    <%= n.nutrient_name %>
-                  <% end %>
-                  <br>
-                  <br>
-                    <%= r.content.truncate(100) %>
-                </div>
-                <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+<div class="highlight-recipes-content">
+  <ul class="recipe-lists jscroll">
+    <% @search_recipes.each do |r| %>
+      <li>
+        <div class="lists">
+          <%# list要素をリンク化%>
+          <%= link_to recipe_path(r.id),class: "recipe-list" do %>
+            <div class="recipe-list-contents">
+              <div class="recipe-text-contents">
+                <h3 class="recipe-title">
+                  <%= r.title %>
+                </h3>
+                <br>
+                登録タグ
+                <br>
+                <% r.tags.each do |t| %>
+                  <%= t.tag_name %>
+                <% end %>
+                <br>
+                <br>
+                栄養素
+                <br>
+                <% r.nutrients.each do |n| %>
+                  <%= n.nutrient_name %>
+                <% end %>
+                <br>
+                <br>
+                  <%= r.content.truncate(100) %>
               </div>
-            <% end %>
-          </div>
-          <%# /list要素をリンク化%>
-        </li>
-      <% end %>
-      <%= paginate @search_recipes %>
-    </ul>
-  </div>
-  
+              <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+            </div>
+          <% end %>
+        </div>
+        <%# /list要素をリンク化%>
+      </li>
+    <% end %>
+    <%= paginate @search_recipes %>
+  </ul>
 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,50 +1,48 @@
-<div class ="main-content">
-  <div class="left-content">
-  <%= render "shared/complex_search" %>
+<div class="left-content">
+<%= render "shared/complex_search" %>
+</div>
+<div class="center-content">
+  <div class="highright-recipes-title">
+    人気レシピ一覧
   </div>
-  <div class="center-content">
-    <div class="highright-recipes-title">
-      人気レシピ一覧
-    </div>
-    <div class="highlight-recipes-content">
-      <ul class="recipe-lists jscroll">
-        <% @search_recipes.each do |r| %>
-          <li>
-            <div class="lists">
-              <%# list要素をリンク化%>
-              <%= link_to recipe_path(r.id),class: "recipe-list" do %>
-                <div class="recipe-list-contents">
-                  <div class="recipe-text-contents">
-                    <h3 class="recipe-title">
-                      <%= r.title %>
-                    </h3>
-                    <br>
-                    登録タグ
-                    <br>
-                    <% r.tags.each do |t| %>
-                      <%= t.tag_name %>
-                    <% end %>
-                    <br>
-                    <br>
-                    栄養素
-                    <br>
-                    <% r.nutrients.each do |n| %>
-                      <%= n.nutrient_name %>
-                    <% end %>
-                    <br>
-                    <br>
-                      <%= r.content.truncate(100) %>
-                  </div>
-                  <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+  <div class="highlight-recipes-content">
+    <ul class="recipe-lists jscroll">
+      <% @search_recipes.each do |r| %>
+        <li>
+          <div class="lists">
+            <%# list要素をリンク化%>
+            <%= link_to recipe_path(r.id),class: "recipe-list" do %>
+              <div class="recipe-list-contents">
+                <div class="recipe-text-contents">
+                  <h3 class="recipe-title">
+                    <%= r.title %>
+                  </h3>
+                  <br>
+                  登録タグ
+                  <br>
+                  <% r.tags.each do |t| %>
+                    <%= t.tag_name %>
+                  <% end %>
+                  <br>
+                  <br>
+                  栄養素
+                  <br>
+                  <% r.nutrients.each do |n| %>
+                    <%= n.nutrient_name %>
+                  <% end %>
+                  <br>
+                  <br>
+                    <%= r.content.truncate(100) %>
                 </div>
-              <% end %>
-            </div>
-            <%# /list要素をリンク化%>
-          </li>
-        <% end %>
-        <%= paginate @search_recipes %>
-      </ul>
-    </div>
-    
+                <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+              </div>
+            <% end %>
+          </div>
+          <%# /list要素をリンク化%>
+        </li>
+      <% end %>
+      <%= paginate @search_recipes %>
+    </ul>
   </div>
+  
 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,41 +1,39 @@
 <%= render "shared/complex_search" %>
 <div class="center-contents">
-  <div class="highright-recipes-title">
-    人気レシピ一覧
+  <div class="posted-recipes-title">
+    投稿レシピ一覧
   </div>
-  <div class="highlight-recipes-content">
+  <div class="posted-recipes-contents">
     <ul class="recipe-lists jscroll">
       <% @search_recipes.each do |r| %>
         <li>
-          <div class="lists">
-            <%# list要素をリンク化%>
-            <%= link_to recipe_path(r.id),class: "recipe-list" do %>
-              <div class="recipe-list-contents">
-                <div class="recipe-text-contents">
-                  <h3 class="recipe-title">
-                    <%= r.title %>
-                  </h3>
-                  <br>
-                  登録タグ
-                  <br>
-                  <% r.tags.each do |t| %>
-                    <%= t.tag_name %>
-                  <% end %>
-                  <br>
-                  <br>
-                  栄養素
-                  <br>
-                  <% r.nutrients.each do |n| %>
-                    <%= n.nutrient_name %>
-                  <% end %>
-                  <br>
-                  <br>
-                    <%= r.content.truncate(100) %>
-                </div>
-                <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+          <%# list要素をリンク化%>
+          <%= link_to recipe_path(r.id),class: "recipe-list" do %>
+            <div class="recipe-list-contents">
+              <div class="recipe-text-contents">
+                <h3 class="recipe-title">
+                  <%= r.title %>
+                </h3>
+                <br>
+                登録タグ
+                <br>
+                <% r.tags.each do |t| %>
+                  <%= t.tag_name %>
+                <% end %>
+                <br>
+                <br>
+                栄養素
+                <br>
+                <% r.nutrients.each do |n| %>
+                  <%= n.nutrient_name %>
+                <% end %>
+                <br>
+                <br>
+                  <%= r.content.truncate(100) %>
               </div>
-            <% end %>
-          </div>
+              <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
+            </div>
+          <% end %>
           <%# /list要素をリンク化%>
         </li>
       <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,42 +1,45 @@
-<div class="highright-recipes-title">
-  人気レシピ一覧
-</div>
-<div class="highlight-recipes-content">
-  <ul class="recipe-lists jscroll">
-    <% @search_recipes.each do |r| %>
-      <li>
-        <div class="lists">
-          <%# list要素をリンク化%>
-          <%= link_to recipe_path(r.id),class: "recipe-list" do %>
-            <div class="recipe-list-contents">
-              <div class="recipe-text-contents">
-                <h3 class="recipe-title">
-                  <%= r.title %>
-                </h3>
-                <br>
-                登録タグ
-                <br>
-                <% r.tags.each do |t| %>
-                  <%= t.tag_name %>
-                <% end %>
-                <br>
-                <br>
-                栄養素
-                <br>
-                <% r.nutrients.each do |n| %>
-                  <%= n.nutrient_name %>
-                <% end %>
-                <br>
-                <br>
-                  <%= r.content.truncate(100) %>
+<%= render "shared/complex_search" %>
+<div class="center-contents">
+  <div class="highright-recipes-title">
+    人気レシピ一覧
+  </div>
+  <div class="highlight-recipes-content">
+    <ul class="recipe-lists jscroll">
+      <% @search_recipes.each do |r| %>
+        <li>
+          <div class="lists">
+            <%# list要素をリンク化%>
+            <%= link_to recipe_path(r.id),class: "recipe-list" do %>
+              <div class="recipe-list-contents">
+                <div class="recipe-text-contents">
+                  <h3 class="recipe-title">
+                    <%= r.title %>
+                  </h3>
+                  <br>
+                  登録タグ
+                  <br>
+                  <% r.tags.each do |t| %>
+                    <%= t.tag_name %>
+                  <% end %>
+                  <br>
+                  <br>
+                  栄養素
+                  <br>
+                  <% r.nutrients.each do |n| %>
+                    <%= n.nutrient_name %>
+                  <% end %>
+                  <br>
+                  <br>
+                    <%= r.content.truncate(100) %>
+                </div>
+                <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
               </div>
-              <%= image_tag r.images[0], class: "recipe-image-content" if r.images.attached? %>
-            </div>
-          <% end %>
-        </div>
-        <%# /list要素をリンク化%>
-      </li>
-    <% end %>
-    <%= paginate @search_recipes %>
-  </ul>
+            <% end %>
+          </div>
+          <%# /list要素をリンク化%>
+        </li>
+      <% end %>
+      <%= paginate @search_recipes %>
+    </ul>
+  </div>
 </div>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,3 +1,4 @@
+<%= render "shared/complex_search" %>
 <div class="center-contents">
   <div class="recipe-post-form">
     <%= form_with model: @recipe, url:recipes_path, local: true do |f| %>

--- a/app/views/recipes/new.html.erb
+++ b/app/views/recipes/new.html.erb
@@ -1,38 +1,40 @@
-<div class="recipe-post-form">
-  <%= form_with model: @recipe, url:recipes_path, local: true do |f| %>
-    <%= render "shared/error_message", model: f.object %>
-    <div class="recipe-post-text">
-      レシピを投稿する
-    </div>
-    <%= f.label "レシピ名" %>
-    <%= f.text_field :title, placeholder:"レシピ名" %>
-    <br>
-    <%= f.label "タグ" %>
-    <%= f.text_field :tag_name, id:"formTagInput", class:"form-control", placeholder:"タグを登録してください。複数つけるには','で区切ってください。" %>
-    <br>
-    <%= f.label "レシピの説明" %>
-    <%= f.text_area :content, placeholder: "レシピの説明" %>
-    <br>
-    <%= f.label "レシピのカテゴリー" %>
-    <%= f.collection_select(:category_id, Category.all, :id, :name, prompt: "カテゴリーを選択してください") %>
-    <%= f.label "完成イメージ" %>
-    <%= f.file_field :images, name:"recipe_ingredient[images][]", id: "recipe_images" %>
-    <br>
-    <div id="image-preview"></div>
-    <%= f.label "材料名" %>
-    <%= f.text_field :material, placeholder:"材料名"%>
-    <br>
-    <%= f.label "分量" %>
-    <%= f.text_field :quantity, placeholder:"分量"%>
-    <br>
-    <%= f.label "作り方" %>
-    <%= f.text_area :description, placeholder: "作り方" %>
-    <br>
-    <%= f.label "摂取できる栄養" %>
-    <%= f.collection_check_boxes :nutrient_ids, Nutrient.all, :id, :nutrient_name do |n| %>
-      <% n.label { n.check_box + n.text} %>
+<div class="center-contents">
+  <div class="recipe-post-form">
+    <%= form_with model: @recipe, url:recipes_path, local: true do |f| %>
+      <%= render "shared/error_message", model: f.object %>
+      <div class="recipe-post-text">
+        レシピを投稿する
+      </div>
+      <%= f.label "レシピ名" %>
+      <%= f.text_field :title, placeholder:"レシピ名" %>
+      <br>
+      <%= f.label "タグ" %>
+      <%= f.text_field :tag_name, id:"formTagInput", class:"form-control", placeholder:"タグを登録してください。複数つけるには','で区切ってください。" %>
+      <br>
+      <%= f.label "レシピの説明" %>
+      <%= f.text_area :content, placeholder: "レシピの説明" %>
+      <br>
+      <%= f.label "レシピのカテゴリー" %>
+      <%= f.collection_select(:category_id, Category.all, :id, :name, prompt: "カテゴリーを選択してください") %>
+      <%= f.label "完成イメージ" %>
+      <%= f.file_field :images, name:"recipe_ingredient[images][]", id: "recipe_images" %>
+      <br>
+      <div id="image-preview"></div>
+      <%= f.label "材料名" %>
+      <%= f.text_field :material, placeholder:"材料名"%>
+      <br>
+      <%= f.label "分量" %>
+      <%= f.text_field :quantity, placeholder:"分量"%>
+      <br>
+      <%= f.label "作り方" %>
+      <%= f.text_area :description, placeholder: "作り方" %>
+      <br>
+      <%= f.label "摂取できる栄養" %>
+      <%= f.collection_check_boxes :nutrient_ids, Nutrient.all, :id, :nutrient_name do |n| %>
+        <% n.label { n.check_box + n.text} %>
+      <% end %>
+      <br>
+      <%= f.submit "投稿する" %>
     <% end %>
-    <br>
-    <%= f.submit "投稿する" %>
-  <% end %>
+  </div>
 </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -30,17 +30,18 @@
       <% end %>
       <br>
       <br>
-      <p>＝＝＝コメント＝＝＝</p>
-      <% if user_signed_in? %>
-        <%= form_with(model: [@recipe,@comment], url: comments_path, method: :post, id: "comment-form")  do |c| %>
-          <%= c.text_area :comment_content %>
-          <%= c.hidden_field :recipe_id, value: @recipe.id %>
-          <%= c.submit "コメントする", id: "comment-submit" %>
+      <div class="posted-comment">
+        <p>＝＝＝コメント＝＝＝</p>
+        <% if user_signed_in? %>
+          <%= form_with(model: [@recipe,@comment], url: comments_path, method: :post, id: "comment-form")  do |c| %>
+            <%= c.text_area :comment_content %>
+            <%= c.hidden_field :recipe_id, value: @recipe.id %>
+            <%= c.submit "コメントする", id: "comment-submit" %>
+          <% end %>
         <% end %>
-      <% end %>
-      <div class="posted-comment"></div>
-      <% @comments.each do |comment| %>
-        <div class="comment-contents"><%= comment.comment_content %></div>
-      <% end %>
+        <% @comments.each do |comment| %>
+          <div class="comment-contents"><%= comment.comment_content %></div>
+        <% end %>
+      </div>
     </div>
   </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,26 +1,30 @@
   <%= render "shared/complex_search" %>
   <div class="center-contents">
     <div class="recipe-show-contents">
-      <div class="recipe-text-contents">
-        <h3 class="recipe-title">
-          <%= @recipe.title %>
-        </h3>
-        <br>
-        <div class='star-btn' id="favorite_<%= @recipe.id %>">
-          <%= render "favorites/favorite", recipe: @recipe %>
+      <div class="recipe-show-items">
+        <div class="recipe-title-contents">
+          <h3 class="recipe-title">
+            <%= @recipe.title %>
+          </h3>
+          <br>
+          <div class='star-btn' id="favorite_<%= @recipe.id %>">
+            <%= render "favorites/favorite", recipe: @recipe %>
+          </div>
+          <br>
+          <span class="recipe-user">
+            <%= @recipe.user.nickname %>
+          </span>
+          <br>
+          <br>
         </div>
-        <br>
-        <span class="recipe-user">
-          <%= @recipe.user.nickname %>
-        </span>
-        <br>
-        <br>
-        <p>
-          <%= @recipe.content %>
-        </p>
+        <%= image_tag @recipe.images[0], class: "recipe-image-content" if @recipe.images.attached? %>
+        <div class="recipe-text-contents">
+          <p>
+            <%= @recipe.content %>
+          </p>
+        </div>
       </div>
       <br>
-      <%= image_tag @recipe.images[0], class: "recipe-image-content" if @recipe.images.attached? %>
       <% if user_signed_in? && current_user.id == @recipe.user_id %>
         <%= link_to "削除する", recipe_path(params[:id]), method: :delete %>
       <% end %>
@@ -36,7 +40,7 @@
       <% end %>
       <div class="posted-comment"></div>
       <% @comments.each do |comment| %>
-        <div class="comment-content"><%= comment.comment_content %></div>
+        <div class="comment-contents"><%= comment.comment_content %></div>
       <% end %>
     </div>
   </div>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -1,42 +1,42 @@
-<div class="recipe-show">
   <%= render "shared/complex_search" %>
-  <div class="recipe-show-contents">
-    <div class="recipe-text-contents">
-      <h3 class="recipe-title">
-        <%= @recipe.title %>
-      </h3>
-      <br>
-      <div class='star-btn' id="favorite_<%= @recipe.id %>">
-        <%= render "favorites/favorite", recipe: @recipe %>
+  <div class="center-contents">
+    <div class="recipe-show-contents">
+      <div class="recipe-text-contents">
+        <h3 class="recipe-title">
+          <%= @recipe.title %>
+        </h3>
+        <br>
+        <div class='star-btn' id="favorite_<%= @recipe.id %>">
+          <%= render "favorites/favorite", recipe: @recipe %>
+        </div>
+        <br>
+        <span class="recipe-user">
+          <%= @recipe.user.nickname %>
+        </span>
+        <br>
+        <br>
+        <p>
+          <%= @recipe.content %>
+        </p>
       </div>
       <br>
-      <span class="recipe-user">
-        <%= @recipe.user.nickname %>
-      </span>
-      <br>
-      <br>
-      <p>
-        <%= @recipe.content %>
-      </p>
-    </div>
-    <br>
-    <%= image_tag @recipe.images[0], class: "recipe-image-content" if @recipe.images.attached? %>
-    <% if user_signed_in? && current_user.id == @recipe.user_id %>
-      <%= link_to "削除する", recipe_path(params[:id]), method: :delete %>
-    <% end %>
-    <br>
-    <br>
-    <p>＝＝＝コメント＝＝＝</p>
-    <% if user_signed_in? %>
-      <%= form_with(model: [@recipe,@comment], url: comments_path, method: :post, id: "comment-form")  do |c| %>
-        <%= c.text_area :comment_content %>
-        <%= c.hidden_field :recipe_id, value: @recipe.id %>
-        <%= c.submit "コメントする", id: "comment-submit" %>
+      <%= image_tag @recipe.images[0], class: "recipe-image-content" if @recipe.images.attached? %>
+      <% if user_signed_in? && current_user.id == @recipe.user_id %>
+        <%= link_to "削除する", recipe_path(params[:id]), method: :delete %>
       <% end %>
-    <% end %>
-    <div class="posted-comment"></div>
-    <% @comments.each do |comment| %>
-      <div class="comment-content"><%= comment.comment_content %></div>
-    <% end %>
+      <br>
+      <br>
+      <p>＝＝＝コメント＝＝＝</p>
+      <% if user_signed_in? %>
+        <%= form_with(model: [@recipe,@comment], url: comments_path, method: :post, id: "comment-form")  do |c| %>
+          <%= c.text_area :comment_content %>
+          <%= c.hidden_field :recipe_id, value: @recipe.id %>
+          <%= c.submit "コメントする", id: "comment-submit" %>
+        <% end %>
+      <% end %>
+      <div class="posted-comment"></div>
+      <% @comments.each do |comment| %>
+        <div class="comment-content"><%= comment.comment_content %></div>
+      <% end %>
+    </div>
   </div>
-</div>

--- a/app/views/shared/_complex_search.html.erb
+++ b/app/views/shared/_complex_search.html.erb
@@ -1,17 +1,19 @@
-    <div class="complex-search">
-      <p>様々な条件で検索</p>
-      <%= search_form_for @search, url: recipes_path do |f| %>
-        <%= f.text_field :title_cont, placeholder: "レシピ名" %>
-        <%= f.label :category_id_eq, "カテゴリ"%>
-        <%= f.collection_select :category_id_eq, Category.all, :id, :name, include_blank: "指定なし" %>
-        <br>
-        栄養
-        <br>
-        <%= f.collection_check_boxes :nutrients_id_eq_any, Nutrient.all, :id, :nutrient_name do |n| %>
-          <% n.label { n.check_box + n.text } %>
-        <% end %>
-        <%= f.label :category_id_eq, "表示順", class:"item" %>
-        <%= f.select( :sorts, {"並び替え": "id desc", "投稿が新しい順": "id desc", "投稿が古い順": "id asc"} ) %>
-        <%= f.submit ("検索する") %>
+<div class="left-contents">
+  <div class="complex-search">
+    <p>様々な条件で検索</p>
+    <%= search_form_for @search, url: recipes_path do |f| %>
+      <%= f.text_field :title_cont, placeholder: "レシピ名" %>
+      <%= f.label :category_id_eq, "カテゴリ"%>
+      <%= f.collection_select :category_id_eq, Category.all, :id, :name, include_blank: "指定なし" %>
+      <br>
+      栄養
+      <br>
+      <%= f.collection_check_boxes :nutrients_id_eq_any, Nutrient.all, :id, :nutrient_name do |n| %>
+        <% n.label { n.check_box + n.text } %>
       <% end %>
-    </div>
+      <%= f.label :category_id_eq, "表示順", class:"item" %>
+      <%= f.select( :sorts, {"並び替え": "id desc", "投稿が新しい順": "id desc", "投稿が古い順": "id asc"} ) %>
+      <%= f.submit ("検索する") %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class="footer-content">
+<div class="footer-contents">
   <div class="copyright">
     Copyright@ hatoya
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<div class="header-all">
-  <div class="header-content">
+<div class="header-contents">
+  <div class="header-items">
     <div class="header-logo">
       <%= link_to("Cook Health", root_path, {class:"logo-text"}) %>
     </div>
@@ -24,19 +24,16 @@
         <li><%= link_to "新規登録", new_user_registration_path %></li>
       <% end %>
     </ul>
-
   </div>
-
-      <div class="menu">
-    <!-- アコーディオンここから -->
-      <a href="#" class="btn">Menu</a>
-      <div class="inner">
-        <ul class="nav">
-        <% if user_signed_in? %>
-          <li><%= link_to "マイページ", user_path(current_user.id), data:{"turbolinks" => false} %></li>
-        <% end %>
-          <li><%= link_to "ヘルプ", "" %></li>
-        </ul>
-      </div>
-    </div> 
+  <div class="menu">
+    <a href="#" class="btn">Menu</a>
+    <div class="inner">
+      <ul class="nav">
+      <% if user_signed_in? %>
+        <li><%= link_to "マイページ", user_path(current_user.id), data:{"turbolinks" => false} %></li>
+      <% end %>
+        <li><%= link_to "ヘルプ", "" %></li>
+      </ul>
+    </div>
+  </div> 
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,31 +1,34 @@
-<div class="user-contents">
-  <div class="user-info">
-    <div class="user-image">
+<%= render "shared/complex_search" %>
+<div class="center-contents">
+  <div class="user-contents">
+    <div class="user-info">
+      <div class="user-image">
+      </div>
+      <div class="user-name">
+      </div>
     </div>
-    <div class="user-name">
-    </div>
-  </div>
-  <div class="user-recipe-contents">
-    <ul class="tab-lists">
-      <li class="my-recipes"><a href="#">マイレシピ</a></li>
-      <li class="favorite-recipes">
-        <a href="#">お気に入りレシピ
-          <% if @favorite_recipes.present? %>
-            <% @favorite_recipes.each do |recipe| %>
-              <%= recipe.title %>
-              <%= recipe.user.content %>
+    <div class="user-recipe-contents">
+      <ul class="tab-lists">
+        <li class="my-recipes"><a href="#">マイレシピ</a></li>
+        <li class="favorite-recipes">
+          <a href="#">お気に入りレシピ
+            <% if @favorite_recipes.present? %>
+              <% @favorite_recipes.each do |recipe| %>
+                <%= recipe.title %>
+                <%= recipe.user.content %>
+              <% end %>
             <% end %>
-          <% end %>
-        </a>
-      </li>
-    </ul>
-    <ul class="tab-contents">
-      <li class="my-recipes">
-        テスト１
-      </li>
-      <li class="favorite-recipes">
-        テスト２
-      </li>
-    </ul>
+          </a>
+        </li>
+      </ul>
+      <ul class="tab-contents">
+        <li class="my-recipes">
+          テスト１
+        </li>
+        <li class="favorite-recipes">
+          テスト２
+        </li>
+      </ul>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## 実装内容
- 各scssファイルの記述修正(記述方法がcssであったものをscssに修正等)
- ページの基本構造を「header-contents/main-contents(left-contents(複雑な検索)/center-contents(各ページのメイン)/footer-contents」に統一(ログイン等divise関係ビュー除く)

## 未実装内容
- メニューボタンのレイアウト修正

**デプロイのため途中マージ**